### PR TITLE
Removes unwanted promotion of byte to signed int

### DIFF
--- a/src/main/java/de/intarsys/pdf/font/CMapBFRangeStringArrayMap.java
+++ b/src/main/java/de/intarsys/pdf/font/CMapBFRangeStringArrayMap.java
@@ -60,7 +60,7 @@ public class CMapBFRangeStringArrayMap extends CMapRangeMap {
                 int charIndex = 0;
                 while (byteIndex < destinationBytes.length) {
                     destinations[i][charIndex++] =
-                            (char) ((destinationBytes[byteIndex++] << 8) + destinationBytes[byteIndex++]);
+                            (char) ((destinationBytes[byteIndex++] << 8) + (destinationBytes[byteIndex++] & 0xff));
                 }
             }
             i++;


### PR DESCRIPTION
When building the char from the byte represenations, we want to add the raw byte instead of it being promoted to a signed int which will result in the wrong char

Fixes: OX-6014

See: https://rules.sonarsource.com/java/RSPEC-3034